### PR TITLE
fixes to alienfile

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -7,14 +7,16 @@ plugin 'PkgConfig' => (
 share {
   plugin 'Download' => (
     url => 'https://www.openssl.org/source/index.html',
-    match => qr/^openssl-[0-9\.]+[a-z]*\.tar\.gz$/,
+    filter => qr/^openssl-[0-9\.]+[a-z]*\.tar\.gz$/,
     version => qr/^openssl-([0-9\.]+[a-z]*)\.tar\.gz$/,
   );
   plugin 'Extract' => 'tar.gz';
-  plugin 'Build::Autoconf' => (with_pic => 0);
+  plugin 'Build::MSYS';
+
   build [
-    '%{configure} no-shared cc',
+    '%{perl} Configure --prefix=%{.install.prefix} no-shared cc',
     '%{make}',
     '%{make} install',
   ];
+
 };


### PR DESCRIPTION
 - s/match/filter/ for download
 - use Alien::MSYS instead of Alien::Autoconf
   although it looks a little like autoconf if you squint,
   Configure is actually a perl (!) script.
 - call Configure with %{perl}